### PR TITLE
add quote from policy doc

### DIFF
--- a/draft-steele-spice-profiles-bcp.md
+++ b/draft-steele-spice-profiles-bcp.md
@@ -87,7 +87,9 @@ smaller message sizes, or advances in data minimization, can be difficult.
 This document provides guidance to policy writers, enabling them to construct
 policies that can be translated into human and machine verifiable profiles,
 enabling digital credential formats to evolve with the speed and precision
-at which policies can be written.
+at which policies can be written. It strives to concretely provide a means for
+"improving ways of working between policy experts and technical experts"
+[Policy experts are IETF stakeholders](https://datatracker.ietf.org/doc/html/draft-hoffmann-gendispatch-policy-stakeholders-03)
 
 # Terminology
 
@@ -255,6 +257,13 @@ This document has no IANA actions.
 
 
 --- back
+
+# Informative References
+[I_D.draft-hoffmann-gendispatch-policy-stakeholders]
+    "Policy experts are IETF stakeholders", Work in Progress, Internet-Draft,
+    draft-hoffmann-gendispatch-policy-stakeholders-03, 10 January 2024,
+    <https://datatracker.ietf.org/doc/html/draft-hoffmann-gendispatch-policy-stakeholders-03>
+
 
 # Acknowledgments
 {:numbered="false"}


### PR DESCRIPTION
This PR fixes Issue #3 by adding a quote from one of the listed documents in a relevant place.

In a large part the listed documents were more orthogonal than directly relevant to this BCP. 

"Policy experts are IETF stakeholders" is primarily about utilizing policy experts in the standards development process, while this bcp aims to create a bridge whereby certain policy experts can more easily utilize particular standards. The bcp is certainly well-harmonized with the spirit of the Stakeholders draft and so I think the quote and link are appropriate, but I don't think we should go further than that.

"IETF Policy Interactions" is a list of interactions between IETF efforts and policy efforts, again primarily as they relate to standards development. I do not think there is much of a link from the Interactions doc to this bcp, but in time it may make sense for the interactions doc to be updated with reference to this bcp.

I am also almost completely guessing about the format for adding an informative link, so adjustments to what I've added would be much appreciated.